### PR TITLE
refactor: cleanup ERC3009

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "coverage": "forge coverage --report lcov && lcov --extract lcov.info -o lcov.info 'src/*' && genhtml lcov.info -o coverage",
-    "prettier": "prettier --write 'script/**/*.sol' 'src/**/*.sol' 'test/**/*.sol'",
+    "prettier": "prettier --write 'src/**/*.sol' 'test/**/*.sol'",
     "slither": "forge build --build-info --skip '*/test/**' --skip '*/script/**' --force && slither --compile-force-framework foundry --ignore-compile --config-file slither.config.json --fail-high .",
     "solhint": "solhint -f stylish 'src/**/*.sol'",
     "solhint-fix": "solhint --fix 'src/**/*.sol'"

--- a/test/utils/ContractHelperHarness.sol
+++ b/test/utils/ContractHelperHarness.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 
 import { ContractHelper } from "../../src/ContractHelper.sol";
 
+/// @title ContractHelper harness used to correctly display test coverage.
 contract ContractHelperHarness {
     function getContractFrom(address account_, uint256 nonce_) external pure returns (address contract_) {
         return ContractHelper.getContractFrom(account_, nonce_);

--- a/test/utils/ERC20ExtendedHarness.sol
+++ b/test/utils/ERC20ExtendedHarness.sol
@@ -2,7 +2,6 @@
 
 pragma solidity 0.8.23;
 
-import { ERC712 } from "../../src/ERC712.sol";
 import { ERC20Extended } from "../../src/ERC20Extended.sol";
 
 contract ERC20ExtendedHarness is ERC20Extended {
@@ -26,6 +25,32 @@ contract ERC20ExtendedHarness is ERC20Extended {
 
     function getDigest(bytes32 internalDigest_) external view returns (bytes32) {
         return _getDigest(internalDigest_);
+    }
+
+    function getTransferWithAuthorizationDigest(
+        address from_,
+        address to_,
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_,
+        bytes32 nonce_
+    ) external view returns (bytes32) {
+        return _getTransferWithAuthorizationDigest(from_, to_, value_, validAfter_, validBefore_, nonce_);
+    }
+
+    function getReceiveWithAuthorizationDigest(
+        address from_,
+        address to_,
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_,
+        bytes32 nonce_
+    ) external view returns (bytes32) {
+        return _getReceiveWithAuthorizationDigest(from_, to_, value_, validAfter_, validBefore_, nonce_);
+    }
+
+    function getCancelAuthorizationDigest(address authorizer_, bytes32 nonce_) external view returns (bytes32) {
+        return _getCancelAuthorizationDigest(authorizer_, nonce_);
     }
 
     /******************************************************************************************************************\

--- a/test/utils/SignatureCheckerHarness.sol
+++ b/test/utils/SignatureCheckerHarness.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.23;
 
 import { SignatureChecker } from "../../src/libs/SignatureChecker.sol";
 
+/// @title SignatureChecker harness used to correctly display test coverage.
 contract SignatureCheckerHarness {
     function decodeECDSASignature(bytes memory signature) external pure returns (uint8 v, bytes32 r, bytes32 s) {
         return SignatureChecker.decodeECDSASignature(signature);

--- a/test/utils/TestUtils.t.sol
+++ b/test/utils/TestUtils.t.sol
@@ -8,69 +8,11 @@ import { ERC20ExtendedHarness } from "./ERC20ExtendedHarness.sol";
 
 contract TestUtils is Test {
     /* ============ Permit ============ */
-    function _signPermit(
+    function _signDigest(
         uint256 signerPrivateKey_,
         bytes32 digest_
     ) internal pure returns (uint8 v_, bytes32 r_, bytes32 s_) {
         (v_, r_, s_) = vm.sign(signerPrivateKey_, digest_);
-    }
-
-    function _getTransferWithAuthorizationDigest(
-        ERC20ExtendedHarness asset_,
-        address from_,
-        address to_,
-        uint256 value_,
-        uint256 validAfter_,
-        uint256 validBefore_,
-        bytes32 fromNonce_
-    ) internal view returns (bytes32 digest_) {
-        return
-            asset_.getDigest(
-                keccak256(
-                    abi.encode(
-                        asset_.TRANSFER_WITH_AUTHORIZATION_TYPEHASH(),
-                        from_,
-                        to_,
-                        value_,
-                        validAfter_,
-                        validBefore_,
-                        fromNonce_
-                    )
-                )
-            );
-    }
-
-    function _getReceiveWithAuthorizationDigest(
-        ERC20ExtendedHarness asset_,
-        address from_,
-        address to_,
-        uint256 value_,
-        uint256 validAfter_,
-        uint256 validBefore_,
-        bytes32 fromNonce_
-    ) internal view returns (bytes32 digest_) {
-        return
-            asset_.getDigest(
-                keccak256(
-                    abi.encode(
-                        asset_.RECEIVE_WITH_AUTHORIZATION_TYPEHASH(),
-                        from_,
-                        to_,
-                        value_,
-                        validAfter_,
-                        validBefore_,
-                        fromNonce_
-                    )
-                )
-            );
-    }
-
-    function _getCancelAuthorizationDigest(
-        ERC20ExtendedHarness asset_,
-        address from_,
-        bytes32 fromNonce_
-    ) internal view returns (bytes32 digest_) {
-        return asset_.getDigest(keccak256(abi.encode(asset_.CANCEL_AUTHORIZATION_TYPEHASH(), from_, fromNonce_)));
     }
 
     function _getVS(uint8 v_, bytes32 s_) internal pure returns (bytes32) {


### PR DESCRIPTION
- merge `_transferWithAuthorizationBefore` and `_transferWithAuthorizationAfter` into `_transferWithAuthorization`
- reduce code duplicate via digest getters
- remove digest getters from utils and expose them in harness
- remove fixture getter `_getTransferParams()` to make tests lighter, more readable, and more flexible
- get internal digests inline in each test
- use constant "random" nonce throughout tests
- check for specific `SignerMismatch` errors where necessary
- enumerate permutations of invalid parameter tests
- remove calls to functions not relevant to unit tests )either entirely or replaced with harness setters)
- remove script directory from prettier targets
- natspec explanation for seemingly redundant library harnesses