### PR TITLE
Add more fuzz tests to Common

### DIFF
--- a/test/ContractHelper.t.sol
+++ b/test/ContractHelper.t.sol
@@ -63,4 +63,16 @@ contract ContractHelperTests is Test {
         vm.setNonce(address(_voidDeployer), 0xffffff + 1);
         assertEq(_contractHelper.getContractFrom(address(_voidDeployer), 0xffffff + 1), _voidDeployer.deploy());
     }
+
+    function testFuzz_full(uint64 nonce) external {
+        // @dev we want to exclude this unrealistic case, which is not covered by the implementation.
+        vm.assume(nonce <= 0xffffffff);
+        vm.assume(nonce != 0x00);
+
+        // @dev deploy new deployer to change address input as well.
+        VoidDeployer newVoidDeployer = new VoidDeployer{salt: keccak256(abi.encode(nonce))}();
+
+        vm.setNonce(address(newVoidDeployer), nonce);
+        assertEq(_contractHelper.getContractFrom(address(newVoidDeployer), nonce), newVoidDeployer.deploy());
+    }
 }

--- a/test/ERC3009.t.sol
+++ b/test/ERC3009.t.sol
@@ -97,6 +97,37 @@ contract ERC3009Tests is TestUtils {
         assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
     }
 
+    function testFuzz_transferWithAuthorization_fullSignature(
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_
+    ) external {
+        validBefore_ = bound(validBefore_, block.timestamp, type(uint256).max);
+        validAfter_ = bound(validAfter_, 0, block.timestamp);
+        assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
+
+        (uint8 v_, bytes32 r_, bytes32 s_) = _signDigest(
+            _aliceKey,
+            _token.getTransferWithAuthorizationDigest(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE)
+        );
+
+        vm.expectEmit();
+        emit IERC3009.AuthorizationUsed(_alice, _SOME_NONCE);
+
+        vm.prank(_charlie);
+        _token.transferWithAuthorization(
+            _alice,
+            _bob,
+            value_,
+            validAfter_,
+            validBefore_,
+            _SOME_NONCE,
+            _encodeSignature(v_, r_, s_)
+        );
+
+        assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
+    }
+
     function test_transferWithAuthorization_rvsSignature() external {
         uint256 value_ = 100;
         uint256 validAfter_ = 0;
@@ -127,10 +158,67 @@ contract ERC3009Tests is TestUtils {
         assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
     }
 
+    function testFuzz_transferWithAuthorization_rvsSignature(
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_
+    ) external {
+        validBefore_ = bound(validBefore_, block.timestamp, type(uint256).max);
+        validAfter_ = bound(validAfter_, 0, block.timestamp);
+
+        assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
+
+        (uint8 v_, bytes32 r_, bytes32 s_) = _signDigest(
+            _aliceKey,
+            _token.getTransferWithAuthorizationDigest(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE)
+        );
+
+        vm.expectEmit();
+        emit IERC3009.AuthorizationUsed(_alice, _SOME_NONCE);
+
+        vm.prank(_charlie);
+        _token.transferWithAuthorization(
+            _alice,
+            _bob,
+            value_,
+            validAfter_,
+            validBefore_,
+            _SOME_NONCE,
+            r_,
+            _getVS(v_, s_)
+        );
+
+        assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
+    }
+
     function test_transferWithAuthorization_vrsSignature() external {
         uint256 value_ = 100;
         uint256 validAfter_ = 0;
         uint256 validBefore_ = type(uint256).max;
+
+        assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
+
+        (uint8 v_, bytes32 r_, bytes32 s_) = _signDigest(
+            _aliceKey,
+            _token.getTransferWithAuthorizationDigest(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE)
+        );
+
+        vm.expectEmit();
+        emit IERC3009.AuthorizationUsed(_alice, _SOME_NONCE);
+
+        vm.prank(_charlie);
+        _token.transferWithAuthorization(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE, v_, r_, s_);
+
+        assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
+    }
+
+    function testFuzz_transferWithAuthorization_vrsSignature(
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_
+    ) external {
+        validBefore_ = bound(validBefore_, block.timestamp, type(uint256).max);
+        validAfter_ = bound(validAfter_, 0, block.timestamp);
 
         assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
 
@@ -307,6 +395,38 @@ contract ERC3009Tests is TestUtils {
         assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
     }
 
+    function testFuzz_receiveWithAuthorization_fullSignature(
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_
+    ) external {
+        validBefore_ = bound(validBefore_, block.timestamp, type(uint256).max);
+        validAfter_ = bound(validAfter_, 0, block.timestamp);
+
+        assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
+
+        (uint8 v_, bytes32 r_, bytes32 s_) = _signDigest(
+            _aliceKey,
+            _token.getReceiveWithAuthorizationDigest(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE)
+        );
+
+        vm.expectEmit();
+        emit IERC3009.AuthorizationUsed(_alice, _SOME_NONCE);
+
+        vm.prank(_bob);
+        _token.receiveWithAuthorization(
+            _alice,
+            _bob,
+            value_,
+            validAfter_,
+            validBefore_,
+            _SOME_NONCE,
+            abi.encodePacked(r_, s_, v_)
+        );
+
+        assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
+    }
+
     function test_receiveWithAuthorization_rvsSignature() external {
         uint256 value_ = 100;
         uint256 validAfter_ = 0;
@@ -337,10 +457,67 @@ contract ERC3009Tests is TestUtils {
         assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
     }
 
+    function testFuzz_receiveWithAuthorization_rvsSignature(
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_
+    ) external {
+        validBefore_ = bound(validBefore_, block.timestamp, type(uint256).max);
+        validAfter_ = bound(validAfter_, 0, block.timestamp);
+
+        assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
+
+        (uint8 v_, bytes32 r_, bytes32 s_) = _signDigest(
+            _aliceKey,
+            _token.getReceiveWithAuthorizationDigest(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE)
+        );
+
+        vm.expectEmit();
+        emit IERC3009.AuthorizationUsed(_alice, _SOME_NONCE);
+
+        vm.prank(_bob);
+        _token.receiveWithAuthorization(
+            _alice,
+            _bob,
+            value_,
+            validAfter_,
+            validBefore_,
+            _SOME_NONCE,
+            r_,
+            _getVS(v_, s_)
+        );
+
+        assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
+    }
+
     function test_receiveWithAuthorization_vrsSignature() external {
         uint256 value_ = 100;
         uint256 validAfter_ = 0;
         uint256 validBefore_ = type(uint256).max;
+
+        assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
+
+        (uint8 v_, bytes32 r_, bytes32 s_) = _signDigest(
+            _aliceKey,
+            _token.getReceiveWithAuthorizationDigest(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE)
+        );
+
+        vm.expectEmit();
+        emit IERC3009.AuthorizationUsed(_alice, _SOME_NONCE);
+
+        vm.prank(_bob);
+        _token.receiveWithAuthorization(_alice, _bob, value_, validAfter_, validBefore_, _SOME_NONCE, v_, r_, s_);
+
+        assertTrue(_token.authorizationState(_alice, _SOME_NONCE));
+    }
+
+    function testFuzz_receiveWithAuthorization_vrsSignature(
+        uint256 value_,
+        uint256 validAfter_,
+        uint256 validBefore_
+    ) external {
+        validBefore_ = bound(validBefore_, block.timestamp, type(uint256).max);
+        validAfter_ = bound(validAfter_, 0, block.timestamp);
 
         assertFalse(_token.authorizationState(_alice, _SOME_NONCE));
 

--- a/test/ERC3009.t.sol
+++ b/test/ERC3009.t.sol
@@ -421,7 +421,7 @@ contract ERC3009Tests is TestUtils {
             validAfter_,
             validBefore_,
             _SOME_NONCE,
-            abi.encodePacked(r_, s_, v_)
+            _encodeSignature(v_, r_, s_)
         );
 
         assertTrue(_token.authorizationState(_alice, _SOME_NONCE));

--- a/test/SignatureChecker.t.sol
+++ b/test/SignatureChecker.t.sol
@@ -492,7 +492,7 @@ contract SignatureCheckerTests is TestUtils {
         assertTrue(_signatureChecker.isValidECDSASignature(account_, digest_, _encodeSignature(v_, r_, s_)));
     }
 
-    function testFuzz_isValidECDSASignature_bytes(uint256 digest) external {
+    function testFuzz_isValidECDSASignature_fullSignature(uint256 digest) external {
         bytes32 digest_ = bytes32(digest);
         (address account_, uint256 privateKey_) = makeAddrAndKey(string(abi.encode("account", digest)));
 

--- a/test/SignatureChecker.t.sol
+++ b/test/SignatureChecker.t.sol
@@ -218,7 +218,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer_, account_);
     }
 
-    function testFuzz_recoverECDSASigner_bytes(uint256 digest) external {
+    function testFuzz_recoverECDSASigner_fullSignature(uint256 digest) external {
         bytes32 digest_ = bytes32(digest);
         (address account_, uint256 privateKey_) = makeAddrAndKey(string(abi.encode("account", digest)));
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(privateKey_, digest_);

--- a/test/SignatureChecker.t.sol
+++ b/test/SignatureChecker.t.sol
@@ -397,7 +397,7 @@ contract SignatureCheckerTests is TestUtils {
         );
     }
 
-    function testFuzz_validateECDSASignature_bytes(uint256 digest) external {
+    function testFuzz_validateECDSASignature_fullSignature(uint256 digest) external {
         bytes32 digest_ = bytes32(digest);
         (address account_, uint256 privateKey_) = makeAddrAndKey(string(abi.encode("account", digest)));
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(privateKey_, digest_);


### PR DESCRIPTION
Add fuzz tests to the following contracts:
- ContractHelper
- ERC3009
- SignatureChecker