### PR TITLE
feat: add `ContinuousIndexingMath`

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,7 +6,7 @@
     {
       "files": "*.sol",
       "options": {
-        "compiler": "0.8.26",
+        "compiler": ">=0.8.20 <0.9.0",
         "parser": "solidity-parse",
         "tabWidth": 4,
         "singleQuote": false,

--- a/.solhint.json
+++ b/.solhint.json
@@ -46,7 +46,7 @@
     "visibility-modifier-order": "error",
     "compiler-version": [
       "warn",
-      "0.8.26"
+      ">=0.8.20 <0.9.0"
     ],
     "func-visibility": [
       "warn",

--- a/src/libs/Bytes32String.sol
+++ b/src/libs/Bytes32String.sol
@@ -7,23 +7,23 @@ pragma solidity >=0.8.20 <0.9.0;
  * @author M^0 Labs
  */
 library Bytes32String {
-    function toBytes32(string memory input_) internal pure returns (bytes32) {
-        return bytes32(abi.encodePacked(input_));
+    function toBytes32(string memory input) internal pure returns (bytes32) {
+        return bytes32(abi.encodePacked(input));
     }
 
-    function toString(bytes32 input_) internal pure returns (string memory) {
-        uint256 length_;
+    function toString(bytes32 input) internal pure returns (string memory) {
+        uint256 length;
 
-        while (length_ < 32 && uint8(input_[length_]) != 0) {
-            ++length_;
+        while (length < 32 && uint8(input[length]) != 0) {
+            ++length;
         }
 
-        bytes memory name_ = new bytes(length_);
+        bytes memory name = new bytes(length);
 
-        for (uint256 index_; index_ < length_; ++index_) {
-            name_[index_] = input_[index_];
+        for (uint256 index; index < length; ++index) {
+            name[index] = input[index];
         }
 
-        return string(name_);
+        return string(name);
     }
 }

--- a/src/libs/ContinuousIndexingMath.sol
+++ b/src/libs/ContinuousIndexingMath.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.8.20 <0.9.0;
+
+import { IndexingMath } from "./IndexingMath.sol";
+
+/**
+ * @title  Arithmetic library with operations for calculating continuous indexing.
+ * @author M^0 Labs
+ */
+library ContinuousIndexingMath {
+    /* ============ Variables ============ */
+
+    /// @notice The scaling of indexes for exponent math.
+    uint56 internal constant EXP_SCALED_ONE = IndexingMath.EXP_SCALED_ONE;
+
+    /// @notice The number of seconds in a year.
+    uint32 internal constant SECONDS_PER_YEAR = 31_536_000;
+
+    /// @notice 100% in basis points.
+    uint16 internal constant BPS_SCALED_ONE = 1e4;
+
+    /* ============ Internal View/Pure Functions ============ */
+
+    /**
+     * @notice Helper function to calculate `(index * deltaIndex) / EXP_SCALED_ONE`, rounded down.
+     * @dev    Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
+     */
+    function multiplyIndicesDown(uint128 index, uint48 deltaIndex) internal pure returns (uint144) {
+        unchecked {
+            return uint144((uint256(index) * deltaIndex) / EXP_SCALED_ONE);
+        }
+    }
+
+    /**
+     * @notice Helper function to calculate `(index * deltaIndex) / EXP_SCALED_ONE`, rounded up.
+     * @dev    Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
+     */
+    function multiplyIndicesUp(uint128 index, uint48 deltaIndex) internal pure returns (uint144) {
+        unchecked {
+            return uint144((uint256(index) * deltaIndex + (EXP_SCALED_ONE - 1)) / EXP_SCALED_ONE);
+        }
+    }
+
+    /**
+     * @notice Helper function to calculate e^rt (continuous compounding formula).
+     * @dev    `uint64 yearlyRate` can accommodate 1000% interest per year.
+     * @dev    `uint32 time` can accommodate 100 years.
+     * @dev    `type(uint64).max * type(uint32).max / SECONDS_PER_YEAR` fits in a `uint72`.
+     */
+    function getContinuousIndex(uint64 yearlyRate, uint32 time) internal pure returns (uint48) {
+        unchecked {
+            // NOTE: Casting `uint256(yearlyRate) * time` to a `uint72` is safe because the largest value is
+            //      `type(uint64).max * type(uint32).max / SECONDS_PER_YEAR`, which is less than `type(uint72).max`.
+            return exponent(uint72((uint256(yearlyRate) * time) / SECONDS_PER_YEAR));
+        }
+    }
+
+    /**
+     * @notice Helper function to calculate y = e^x using R(4,4) Padé approximation:
+     *           e(x) = (1 + x/2 + 3(x^2)/28 + x^3/84 + x^4/1680) / (1 - x/2 + 3(x^2)/28 - x^3/84 + x^4/1680)
+     *           See: https://en.wikipedia.org/wiki/Pad%C3%A9_table
+     *           See: https://www.wolframalpha.com/input?i=PadeApproximant%5Bexp%5Bx%5D%2C%7Bx%2C0%2C%7B4%2C+4%7D%7D%5D
+     *         Despite itself being a whole number, `x` represents a real number scaled by `EXP_SCALED_ONE`, thus
+     *         allowing for y = e^x where x is a real number.
+     * @dev    Output for a `uint72` input `x` will fit in `uint48`
+     */
+    function exponent(uint72 x) internal pure returns (uint48) {
+        // NOTE: This can be done unchecked even for `x = type(uint72).max`.
+        //       Verify by removing `unchecked` and running `test_exponent()`.
+        unchecked {
+            uint256 x2 = uint256(x) * x;
+
+            // `additiveTerms` is `(1 + 3(x^2)/28 + x^4/1680)`, and scaled by `84e27`.
+            // NOTE: `84e27` the cleanest and largest scalar, given the various intermediate overflow possibilities.
+            // NOTE: The resulting `(x2 * x2) / 20e21` term has been split to avoid overflow of `x2 * x2`.
+            uint256 additiveTerms = 84e27 + (9e3 * x2) + ((x2 / 2e11) * (x2 / 1e11));
+
+            // `differentTerms` is `(- x/2 - x^3/84)`, but positive (will be subtracted later), and scaled by `84e27`.
+            uint256 differentTerms = uint256(x) * (42e15 + (x2 / 1e9));
+
+            // Result needs to be scaled by `1e12`.
+            // NOTE: Can cast to `uint48` because contents can never be larger than `type(uint48).max` for any `x`.
+            //       Max `y` is ~200e12, before falling off. See links above for reference.
+            return uint48(((additiveTerms + differentTerms) * 1e12) / (additiveTerms - differentTerms));
+        }
+    }
+
+    /**
+     * @notice Helper function to convert a scaled 12-decimal percentage to basis points.
+     * @param  input A percentage represented as a scaled 12-decimal number.
+     * @return The percentage represented as basis points.
+     */
+    function convertToBasisPoints(uint64 input) internal pure returns (uint40) {
+        unchecked {
+            return uint40((uint256(input) * BPS_SCALED_ONE) / EXP_SCALED_ONE);
+        }
+    }
+
+    /**
+     * @notice Helper function to convert basis points to a scaled 12-decimal percentage.
+     * @param  input A percentage represented as basis points.
+     * @return The percentage represented as a scaled 12-decimal number.
+     */
+    function convertFromBasisPoints(uint32 input) internal pure returns (uint64) {
+        unchecked {
+            return uint64((uint256(input) * EXP_SCALED_ONE) / BPS_SCALED_ONE);
+        }
+    }
+}

--- a/src/libs/ContractHelper.sol
+++ b/src/libs/ContractHelper.sol
@@ -21,51 +21,51 @@ pragma solidity >=0.8.20 <0.9.0;
  */
 library ContractHelper {
     /**
-     * @notice Returns the expected address of a contract deployed by `account_` with transaction count `nonce_`.
-     * @param  account_  The address of the account deploying a contract.
-     * @param  nonce_    The nonce used in the deployment transaction.
-     * @return contract_ The expected address of the deployed contract.
+     * @notice Returns the expected address of a contract deployed by `account` with transaction count `nonce`.
+     * @param  account The address of the account deploying a contract.
+     * @param  nonce   The nonce used in the deployment transaction.
+     * @return The expected address of the deployed contract.
      */
-    function getContractFrom(address account_, uint256 nonce_) internal pure returns (address contract_) {
+    function getContractFrom(address account, uint256 nonce) internal pure returns (address) {
         return
             address(
                 uint160(
                     uint256(
                         keccak256(
-                            nonce_ == 0x00
-                                ? abi.encodePacked(bytes1(0xd6), bytes1(0x94), account_, bytes1(0x80))
-                                : nonce_ <= 0x7f
-                                    ? abi.encodePacked(bytes1(0xd6), bytes1(0x94), account_, uint8(nonce_))
-                                    : nonce_ <= 0xff
+                            nonce == 0x00
+                                ? abi.encodePacked(bytes1(0xd6), bytes1(0x94), account, bytes1(0x80))
+                                : nonce <= 0x7f
+                                    ? abi.encodePacked(bytes1(0xd6), bytes1(0x94), account, uint8(nonce))
+                                    : nonce <= 0xff
                                         ? abi.encodePacked(
                                             bytes1(0xd7),
                                             bytes1(0x94),
-                                            account_,
+                                            account,
                                             bytes1(0x81),
-                                            uint8(nonce_)
+                                            uint8(nonce)
                                         )
-                                        : nonce_ <= 0xffff
+                                        : nonce <= 0xffff
                                             ? abi.encodePacked(
                                                 bytes1(0xd8),
                                                 bytes1(0x94),
-                                                account_,
+                                                account,
                                                 bytes1(0x82),
-                                                uint16(nonce_)
+                                                uint16(nonce)
                                             )
-                                            : nonce_ <= 0xffffff
+                                            : nonce <= 0xffffff
                                                 ? abi.encodePacked(
                                                     bytes1(0xd9),
                                                     bytes1(0x94),
-                                                    account_,
+                                                    account,
                                                     bytes1(0x83),
-                                                    uint24(nonce_)
+                                                    uint24(nonce)
                                                 )
                                                 : abi.encodePacked(
                                                     bytes1(0xda),
                                                     bytes1(0x94),
-                                                    account_,
+                                                    account,
                                                     bytes1(0x84),
-                                                    uint32(nonce_)
+                                                    uint32(nonce)
                                                 )
                         )
                     )

--- a/src/libs/IndexingMath.sol
+++ b/src/libs/IndexingMath.sol
@@ -19,14 +19,14 @@ library IndexingMath {
     /// @notice Emitted when a division by zero occurs.
     error DivisionByZero();
 
-    /* ============ Internal View/Pure Functions ============ */
+    /* ============ Exposed Functions ============ */
 
     /**
      * @notice Helper function to calculate `(x * EXP_SCALED_ONE) / y`, rounded down.
      * @dev    Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
      */
-    function divide240By128Down(uint240 x_, uint128 y_) internal pure returns (uint112) {
-        if (y_ == 0) revert DivisionByZero();
+    function divide240By128Down(uint240 x, uint128 y) internal pure returns (uint112) {
+        if (y == 0) revert DivisionByZero();
 
         unchecked {
             // NOTE: While `uint256(x) * EXP_SCALED_ONE` can technically overflow, these divide/multiply functions are
@@ -34,7 +34,7 @@ library IndexingMath {
             //       so for an `x` to be large enough to overflow this, it would have to be a possible result of
             //       `multiply112By128Down` or `multiply112By128Up`, which would already satisfy
             //       `uint256(x) * EXP_SCALED_ONE < type(uint240).max`.
-            return UIntMath.safe112((uint256(x_) * EXP_SCALED_ONE) / y_);
+            return UIntMath.safe112((uint256(x) * EXP_SCALED_ONE) / y);
         }
     }
 
@@ -42,8 +42,8 @@ library IndexingMath {
      * @notice Helper function to calculate `(x * EXP_SCALED_ONE) / y`, rounded up.
      * @dev    Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
      */
-    function divide240By128Up(uint240 x_, uint128 y_) internal pure returns (uint112) {
-        if (y_ == 0) revert DivisionByZero();
+    function divide240By128Up(uint240 x, uint128 y) internal pure returns (uint112) {
+        if (y == 0) revert DivisionByZero();
 
         unchecked {
             // NOTE: While `uint256(x) * EXP_SCALED_ONE` can technically overflow, these divide/multiply functions are
@@ -51,7 +51,7 @@ library IndexingMath {
             //       so for an `x` to be large enough to overflow this, it would have to be a possible result of
             //       `multiply112By128Down` or `multiply112By128Up`, which would already satisfy
             //       `uint256(x) * EXP_SCALED_ONE < type(uint240).max`.
-            return UIntMath.safe112(((uint256(x_) * EXP_SCALED_ONE) + y_ - 1) / y_);
+            return UIntMath.safe112(((uint256(x) * EXP_SCALED_ONE) + y - 1) / y);
         }
     }
 
@@ -59,39 +59,49 @@ library IndexingMath {
      * @notice Helper function to calculate `(x * y) / EXP_SCALED_ONE`, rounded down.
      * @dev    Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
      */
-    function multiply112By128Down(uint112 x_, uint128 y_) internal pure returns (uint240) {
+    function multiply112By128Down(uint112 x, uint128 y) internal pure returns (uint240) {
         unchecked {
-            return uint240((uint256(x_) * y_) / EXP_SCALED_ONE);
+            return uint240((uint256(x) * y) / EXP_SCALED_ONE);
+        }
+    }
+
+    /**
+     * @notice Helper function to calculate `(x * index) / EXP_SCALED_ONE`, rounded up.
+     * @dev    Inspired by USM (https://github.com/usmfum/USM/blob/master/contracts/WadMath.sol)
+     */
+    function multiply112By128Up(uint112 x, uint128 index) internal pure returns (uint240 z) {
+        unchecked {
+            return uint240(((uint256(x) * index) + (EXP_SCALED_ONE - 1)) / EXP_SCALED_ONE);
         }
     }
 
     /**
      * @dev    Returns the present amount (rounded down) given the principal amount and an index.
-     * @param  principalAmount_ The principal amount.
-     * @param  index_           An index.
+     * @param  principalAmount The principal amount.
+     * @param  index           An index.
      * @return The present amount rounded down.
      */
-    function getPresentAmountRoundedDown(uint112 principalAmount_, uint128 index_) internal pure returns (uint240) {
-        return multiply112By128Down(principalAmount_, index_);
+    function getPresentAmountRoundedDown(uint112 principalAmount, uint128 index) internal pure returns (uint240) {
+        return multiply112By128Down(principalAmount, index);
     }
 
     /**
      * @dev    Returns the principal amount given the present amount, using the current index.
-     * @param  presentAmount_ The present amount.
-     * @param  index_         An index.
+     * @param  presentAmount The present amount.
+     * @param  index         An index.
      * @return The principal amount rounded down.
      */
-    function getPrincipalAmountRoundedDown(uint240 presentAmount_, uint128 index_) internal pure returns (uint112) {
-        return divide240By128Down(presentAmount_, index_);
+    function getPrincipalAmountRoundedDown(uint240 presentAmount, uint128 index) internal pure returns (uint112) {
+        return divide240By128Down(presentAmount, index);
     }
 
     /**
      * @dev    Returns the principal amount given the present amount, using the current index.
-     * @param  presentAmount_ The present amount.
-     * @param  index_         An index.
+     * @param  presentAmount The present amount.
+     * @param  index         An index.
      * @return The principal amount rounded up.
      */
-    function getPrincipalAmountRoundedUp(uint240 presentAmount_, uint128 index_) internal pure returns (uint112) {
-        return divide240By128Up(presentAmount_, index_);
+    function getPrincipalAmountRoundedUp(uint240 presentAmount, uint128 index) internal pure returns (uint112) {
+        return divide240By128Up(presentAmount, index);
     }
 }

--- a/src/libs/SignatureChecker.sol
+++ b/src/libs/SignatureChecker.sol
@@ -57,14 +57,14 @@ library SignatureChecker {
         bytes32 digest,
         bytes memory signature
     ) internal view returns (bool) {
-        (bool success, bytes memory result) = signer.staticcall(
+        (bool success_, bytes memory result_) = signer.staticcall(
             abi.encodeCall(IERC1271.isValidSignature, (digest, signature))
         );
 
         return
-            success &&
-            result.length >= 32 &&
-            abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector);
+            success_ &&
+            result_.length >= 32 &&
+            abi.decode(result_, (bytes32)) == bytes32(IERC1271.isValidSignature.selector);
     }
 
     /**
@@ -122,11 +122,11 @@ library SignatureChecker {
 
     /**
      * @dev    Returns whether an ECDSA/secp256k1 short signature is valid for a signer and digest.
-     * @param  signer  The address of the account purported to have signed.
-     * @param  digest  The hash of the data that was signed.
-     * @param  r       An ECDSA/secp256k1 signature parameter.
-     * @param  vs      An ECDSA/secp256k1 short signature parameter.
-     * @return         Whether the signature is valid or not.
+     * @param  signer The address of the account purported to have signed.
+     * @param  digest The hash of the data that was signed.
+     * @param  r      An ECDSA/secp256k1 signature parameter.
+     * @param  vs     An ECDSA/secp256k1 short signature parameter.
+     * @return        Whether the signature is valid or not.
      */
     function isValidECDSASignature(address signer, bytes32 digest, bytes32 r, bytes32 vs) internal pure returns (bool) {
         return validateECDSASignature(signer, digest, r, vs) == Error.NoError;

--- a/src/libs/UIntMath.sol
+++ b/src/libs/UIntMath.sol
@@ -30,9 +30,8 @@ library UIntMath {
     /* ============ Internal View/Pure Functions ============ */
 
     /**
-     * @notice Casts a given uint256 value to a uint16,
-     *         ensuring that it is less than or equal to the maximum uint16 value.
-     * @param  n The value to check.
+     * @notice Casts a uint256 value to a uint16, ensuring that it is less than or equal to the maximum uint16 value.
+     * @param  n The value to cast.
      * @return The value casted to uint16.
      */
     function safe16(uint256 n) internal pure returns (uint16) {
@@ -41,9 +40,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Casts a given uint256 value to a uint40,
-     *         ensuring that it is less than or equal to the maximum uint40 value.
-     * @param  n The value to check.
+     * @notice Casts a uint256 value to a uint40, ensuring that it is less than or equal to the maximum uint40 value.
+     * @param  n The value to cast.
      * @return The value casted to uint40.
      */
     function safe40(uint256 n) internal pure returns (uint40) {
@@ -52,9 +50,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Casts a given uint256 value to a uint48,
-     *         ensuring that it is less than or equal to the maximum uint48 value.
-     * @param  n The value to check.
+     * @notice Casts a uint256 value to a uint48, ensuring that it is less than or equal to the maximum uint48 value.
+     * @param  n The value to cast.
      * @return The value casted to uint48.
      */
     function safe48(uint256 n) internal pure returns (uint48) {
@@ -63,9 +60,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Casts a given uint256 value to a uint112,
-     *         ensuring that it is less than or equal to the maximum uint112 value.
-     * @param  n The value to check.
+     * @notice Casts a uint256 value to a uint112, ensuring that it is less than or equal to the maximum uint112 value.
+     * @param  n The value to cast.
      * @return The value casted to uint112.
      */
     function safe112(uint256 n) internal pure returns (uint112) {
@@ -74,9 +70,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Casts a given uint256 value to a uint128,
-     *         ensuring that it is less than or equal to the maximum uint128 value.
-     * @param  n The value to check.
+     * @notice Casts a uint256 value to a uint128, ensuring that it is less than or equal to the maximum uint128 value.
+     * @param  n The value to cast.
      * @return The value casted to uint128.
      */
     function safe128(uint256 n) internal pure returns (uint128) {
@@ -85,9 +80,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Casts a given uint256 value to a uint240,
-     *         ensuring that it is less than or equal to the maximum uint240 value.
-     * @param  n The value to check.
+     * @notice Casts a uint256 value to a uint240, ensuring that it is less than or equal to the maximum uint240 value.
+     * @param  n The value to cast.
      * @return The value casted to uint240.
      */
     function safe240(uint256 n) internal pure returns (uint240) {
@@ -96,8 +90,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Limits a given uint256 value to the maximum uint32 value.
-     * @param  n The value to check.
+     * @notice Limits a uint256 value to the maximum uint32 value.
+     * @param  n The value to bound.
      * @return The value limited to within uint32 bounds.
      */
     function bound32(uint256 n) internal pure returns (uint32) {
@@ -105,8 +99,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Limits a given uint256 value to the maximum uint112 value.
-     * @param  n The value to check.
+     * @notice Limits a uint256 value to the maximum uint112 value.
+     * @param  n The value to bound.
      * @return The value limited to within uint112 bounds.
      */
     function bound112(uint256 n) internal pure returns (uint112) {
@@ -114,8 +108,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Limits a given uint256 value to the maximum uint128 value.
-     * @param  n The value to check.
+     * @notice Limits a uint256 value to the maximum uint128 value.
+     * @param  n The value to bound.
      * @return The value limited to within uint128 bounds.
      */
     function bound128(uint256 n) internal pure returns (uint128) {
@@ -123,8 +117,8 @@ library UIntMath {
     }
 
     /**
-     * @notice Limits a given uint256 value to the maximum uint240 value.
-     * @param  n The value to check.
+     * @notice Limits a uint256 value to the maximum uint240 value.
+     * @param  n The value to bound.
      * @return The value limited to within uint240 bounds.
      */
     function bound240(uint256 n) internal pure returns (uint240) {
@@ -133,71 +127,71 @@ library UIntMath {
 
     /**
      * @notice Compares two uint32 values and returns the larger one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The larger value.
      */
-    function max32(uint32 a_, uint32 b_) internal pure returns (uint32) {
-        return a_ > b_ ? a_ : b_;
+    function max32(uint32 a, uint32 b) internal pure returns (uint32) {
+        return a > b ? a : b;
     }
 
     /**
      * @notice Compares two uint40 values and returns the larger one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The larger value.
      */
-    function max40(uint40 a_, uint40 b_) internal pure returns (uint40) {
-        return a_ > b_ ? a_ : b_;
+    function max40(uint40 a, uint40 b) internal pure returns (uint40) {
+        return a > b ? a : b;
     }
 
     /**
      * @notice Compares two uint32 values and returns the lesser one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The lesser value.
      */
-    function min32(uint32 a_, uint32 b_) internal pure returns (uint32) {
-        return a_ < b_ ? a_ : b_;
+    function min32(uint32 a, uint32 b) internal pure returns (uint32) {
+        return a < b ? a : b;
     }
 
     /**
      * @notice Compares two uint40 values and returns the lesser one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The lesser value.
      */
-    function min40(uint40 a_, uint40 b_) internal pure returns (uint40) {
-        return a_ < b_ ? a_ : b_;
+    function min40(uint40 a, uint40 b) internal pure returns (uint40) {
+        return a < b ? a : b;
     }
 
     /**
      * @notice Compares two uint240 values and returns the lesser one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The lesser value.
      */
-    function min240(uint240 a_, uint240 b_) internal pure returns (uint240) {
-        return a_ < b_ ? a_ : b_;
+    function min240(uint240 a, uint240 b) internal pure returns (uint240) {
+        return a < b ? a : b;
     }
 
     /**
      * @notice Compares two uint112 values and returns the lesser one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The lesser value.
      */
-    function min112(uint112 a_, uint112 b_) internal pure returns (uint112) {
-        return a_ < b_ ? a_ : b_;
+    function min112(uint112 a, uint112 b) internal pure returns (uint112) {
+        return a < b ? a : b;
     }
 
     /**
      * @notice Compares two uint256 values and returns the lesser one.
-     * @param  a_  Value to check.
-     * @param  b_  Value to check.
+     * @param  a Value to compare.
+     * @param  b Value to compare.
      * @return The lesser value.
      */
-    function min256(uint256 a_, uint256 b_) internal pure returns (uint256) {
-        return a_ < b_ ? a_ : b_;
+    function min256(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
     }
 }

--- a/test/Bytes32String.sol
+++ b/test/Bytes32String.sol
@@ -13,7 +13,7 @@ contract Bytes32StringTests is Test {
         _bytes32String = new Bytes32StringHarness();
     }
 
-    function test_full() external {
+    function test_full() external view {
         assertEq(_bytes32String.toString(_bytes32String.toBytes32("")), "");
         assertEq(_bytes32String.toString(_bytes32String.toBytes32("T")), "T");
         assertEq(_bytes32String.toString(_bytes32String.toBytes32("Te")), "Te");
@@ -93,7 +93,7 @@ contract Bytes32StringTests is Test {
         );
     }
 
-    function testFuzz_full(string memory input_) external {
+    function testFuzz_full(string memory input_) external view {
         assertEq(_bytes32String.toString(_bytes32String.toBytes32(input_)), _truncate32(input_));
     }
 

--- a/test/ContinuousIndexingMath.t.sol
+++ b/test/ContinuousIndexingMath.t.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.20 <0.9.0;
+
+import { Test } from "../lib/forge-std/src/Test.sol";
+
+import { ContinuousIndexingMath } from "../src/libs/ContinuousIndexingMath.sol";
+import { IndexingMath } from "../src/libs/IndexingMath.sol";
+
+import { ContinuousIndexingMathHarness } from "./utils/ContinuousIndexingMathHarness.sol";
+
+contract ContinuousIndexingMathTests is Test {
+    uint56 internal constant _EXP_SCALED_ONE = ContinuousIndexingMath.EXP_SCALED_ONE;
+
+    ContinuousIndexingMathHarness public continuousIndexingMath;
+
+    function setUp() external {
+        continuousIndexingMath = new ContinuousIndexingMathHarness();
+    }
+
+    function test_exponent() external view {
+        assertEq(continuousIndexingMath.exponent(0), 1_000000000000); // actual 1
+
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE / 10000), 1_000100005000); // actual 1.0001000050001667
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE / 1000), 1_001000500166); // actual 1.0010005001667084
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE / 100), 1_010050167084); // actual 1.010050167084168
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE / 10), 1_105170918075); // actual 1.1051709180756477
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE / 2), 1_648721270572); // actual 1.6487212707001282
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE), 2_718281718281); // actual 2.718281828459045
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE * 2), 7_388888888888); // actual 7.3890560989306495
+
+        // Demonstrate maximum of ~200e12.
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE * 5), 128_619047619047);
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE * 6), 196_000000000000);
+        assertEq(continuousIndexingMath.exponent(_EXP_SCALED_ONE * 7), 159_260869565217);
+
+        // If `unchecked` is removed from `exponent`, it will not overflow (lot's of error nonetheless).
+        assertEq(continuousIndexingMath.exponent(type(uint72).max), 1_000000008470);
+    }
+
+    function test_getContinuousIndex() external view {
+        assertEq(continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 0), 1_000000000000); // 1
+        assertEq(continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 1 days), 1_002743482506); // 1.00274348
+        assertEq(continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 10 days), 1_027776016255); // 1.02777602
+        assertEq(continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 365 days), 2718281718281); // 2.71828183
+    }
+
+    function test_multiplyContinuousRates() external {
+        uint256 oneHourRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 1 hours);
+        uint256 twoHourRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 2 hours);
+        uint256 fourHourRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 4 hours);
+        uint256 sixteenHourRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 16 hours);
+        uint256 oneDayRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 1 days);
+        uint256 twoDayRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 2 days);
+
+        uint256 oneInExp = uint256(_EXP_SCALED_ONE);
+
+        assertEqPrecision((oneHourRate * oneHourRate) / oneInExp, twoHourRate, 1e1);
+
+        assertEqPrecision(
+            (oneHourRate * oneHourRate * oneHourRate * oneHourRate) / (oneInExp * oneInExp * oneInExp),
+            fourHourRate,
+            1e2
+        );
+
+        assertEqPrecision(
+            (fourHourRate * fourHourRate * fourHourRate * fourHourRate) / (oneInExp * oneInExp * oneInExp),
+            sixteenHourRate,
+            1e1
+        );
+
+        assertEqPrecision((sixteenHourRate * fourHourRate * fourHourRate) / (oneInExp * oneInExp), oneDayRate, 1e1);
+
+        assertEqPrecision(
+            (sixteenHourRate * sixteenHourRate * sixteenHourRate) / (oneInExp * oneInExp),
+            twoDayRate,
+            1e1
+        );
+
+        assertEqPrecision((oneDayRate * oneDayRate) / oneInExp, twoDayRate, 1e1);
+    }
+
+    function test_multiplyThenDivide_100apy() external view {
+        uint112 amount = 1_000e6;
+        uint128 sevenDayRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 7 days);
+        uint128 thirtyDayRate = continuousIndexingMath.getContinuousIndex(_EXP_SCALED_ONE, 30 days);
+
+        assertEq(
+            IndexingMath.divide240By128Down(IndexingMath.multiply112By128Down(amount, sevenDayRate), sevenDayRate),
+            amount - 1
+        );
+        assertEq(
+            IndexingMath.multiply112By128Down(IndexingMath.divide240By128Down(amount, sevenDayRate), sevenDayRate),
+            amount - 1
+        );
+
+        assertEq(
+            IndexingMath.divide240By128Down(IndexingMath.multiply112By128Down(amount, thirtyDayRate), thirtyDayRate),
+            amount - 1
+        );
+        assertEq(
+            IndexingMath.multiply112By128Down(IndexingMath.divide240By128Down(amount, thirtyDayRate), thirtyDayRate),
+            amount - 1
+        );
+    }
+
+    function test_multiplyThenDivide_6apy() external view {
+        uint112 amount = 1_000e6;
+        uint128 sevenDayRate = continuousIndexingMath.getContinuousIndex((_EXP_SCALED_ONE * 6) / 100, 7 days);
+        uint128 thirtyDayRate = continuousIndexingMath.getContinuousIndex((_EXP_SCALED_ONE * 6) / 100, 30 days);
+
+        assertEq(
+            IndexingMath.divide240By128Down(IndexingMath.multiply112By128Down(amount, sevenDayRate), sevenDayRate),
+            amount - 1
+        );
+        assertEq(
+            IndexingMath.multiply112By128Down(IndexingMath.divide240By128Down(amount, sevenDayRate), sevenDayRate),
+            amount - 1
+        );
+
+        assertEq(
+            IndexingMath.divide240By128Down(IndexingMath.multiply112By128Down(amount, thirtyDayRate), thirtyDayRate),
+            amount - 1
+        );
+        assertEq(
+            IndexingMath.multiply112By128Down(IndexingMath.divide240By128Down(amount, thirtyDayRate), thirtyDayRate),
+            amount - 1
+        );
+    }
+
+    function test_convertToBasisPoints() external view {
+        assertEq(continuousIndexingMath.convertToBasisPoints(1_000000000000), 10_000);
+        assertEq(continuousIndexingMath.convertToBasisPoints(type(uint64).max), 184467440_737);
+    }
+
+    function test_convertFromBasisPoints() external view {
+        assertEq(continuousIndexingMath.convertFromBasisPoints(10_000), 1_000000000000);
+        assertEq(continuousIndexingMath.convertFromBasisPoints(type(uint32).max), 429496_729500000000);
+    }
+
+    function test_exponentLimits() external view {
+        uint72 x = 6_101171897009;
+        uint48 maxExponent = 196_691035579298;
+
+        assertEq(continuousIndexingMath.exponent(x), maxExponent); // Max of exponent.
+
+        assertLe(continuousIndexingMath.exponent(x - 1), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x - 10), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x - 100), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x - 1000), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x - 10000), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x - 100000), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x - 1000000), maxExponent);
+
+        assertLe(continuousIndexingMath.exponent(x + 1), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x + 10), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x + 100), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x + 1000), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x + 10000), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x + 100000), maxExponent);
+        assertLe(continuousIndexingMath.exponent(x + 1000000), maxExponent);
+
+        uint256 maxYearlyRateGivenHourlyUpdates = (x * 365 days) / 1 hours;
+        uint256 maxYearlyRateGivenYearlyUpdates = (x * 365 days) / 365 days;
+
+        assertEq(maxYearlyRateGivenHourlyUpdates, 53446_265817798840); // 5,344,626%
+        assertEq(maxYearlyRateGivenYearlyUpdates, 6_101171897009); // 610%
+
+        assertTrue(maxYearlyRateGivenHourlyUpdates < type(uint64).max);
+        assertTrue(maxYearlyRateGivenYearlyUpdates < type(uint64).max);
+
+        assertEq(continuousIndexingMath.convertToBasisPoints(uint64(maxYearlyRateGivenHourlyUpdates)), 534462_658); // 5,344,626.58%
+        assertEq(continuousIndexingMath.convertToBasisPoints(uint64(maxYearlyRateGivenYearlyUpdates)), 61_011); // 610.11%
+
+        assertEq(
+            continuousIndexingMath.getContinuousIndex(uint64(maxYearlyRateGivenHourlyUpdates), 1 hours),
+            maxExponent
+        );
+        assertEq(
+            continuousIndexingMath.getContinuousIndex(uint64(maxYearlyRateGivenYearlyUpdates), 365 days),
+            maxExponent
+        );
+    }
+
+    function test_indexLimits_hourlyAt1000APY() external view {
+        // 6 years of hourly updates at 1000% APY.
+        uint128 index = _EXP_SCALED_ONE;
+
+        for (uint256 i; i < 52_560; ++i) {
+            index = uint128(
+                continuousIndexingMath.multiplyIndicesDown(
+                    index,
+                    continuousIndexingMath.getContinuousIndex(
+                        continuousIndexingMath.convertFromBasisPoints(100_000), // 1000%
+                        1 hours
+                    )
+                )
+            );
+        }
+    }
+
+    function test_indexLimits_dailyAt100APY() external view {
+        // 60 years of daily updates at 100% APY.
+        uint128 index = _EXP_SCALED_ONE;
+
+        for (uint256 i; i < 21_900; ++i) {
+            index = uint128(
+                continuousIndexingMath.multiplyIndicesDown(
+                    index,
+                    continuousIndexingMath.getContinuousIndex(
+                        continuousIndexingMath.convertFromBasisPoints(10_000), // 100%
+                        1 days
+                    )
+                )
+            );
+        }
+    }
+
+    function test_indexLimits_dailyAt10APY() external view {
+        // 100 years of daily updates at 10% APY.
+        uint128 index = _EXP_SCALED_ONE;
+
+        for (uint256 i; i < 36_500; ++i) {
+            index = uint128(
+                continuousIndexingMath.multiplyIndicesDown(
+                    index,
+                    continuousIndexingMath.getContinuousIndex(
+                        continuousIndexingMath.convertFromBasisPoints(1_000), // 10%
+                        1 days
+                    )
+                )
+            );
+        }
+    }
+
+    function assertEqPrecision(uint256 a_, uint256 b_, uint256 precision_) internal {
+        if (a_ / precision_ != b_ / precision_) {
+            emit log("Error: a == b not satisfied [uint]");
+            emit log_named_uint("      Left", a_);
+            emit log_named_uint("     Right", b_);
+            fail();
+        }
+    }
+}

--- a/test/ERC20Extended.t.sol
+++ b/test/ERC20Extended.t.sol
@@ -30,14 +30,14 @@ contract ERC20ExtendedTests is TestUtils {
     }
 
     /* ============ constructor ============ */
-    function test_constructor() public {
+    function test_constructor() external view {
         assertEq(_token.name(), _TOKEN_NAME);
         assertEq(_token.symbol(), _TOKEN_SYMBOL);
         assertEq(_token.decimals(), _TOKEN_DECIMALS);
     }
 
     /* ============ eip712Domain ============ */
-    function test_eip712Domain() public {
+    function test_eip712Domain() external view {
         (
             bytes1 fields_,
             string memory name_,
@@ -58,7 +58,7 @@ contract ERC20ExtendedTests is TestUtils {
     }
 
     /* ============ mint ============ */
-    function test_mint() public {
+    function test_mint() external {
         uint256 amount_ = 1e18;
 
         vm.expectEmit();
@@ -70,7 +70,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.balanceOf(_alice), amount_);
     }
 
-    function testFuzz_mint(address from_, uint256 amount_) public {
+    function testFuzz_mint(address from_, uint256 amount_) external {
         vm.assume(from_ != address(0));
 
         amount_ = bound(amount_, 1, type(uint256).max);
@@ -82,7 +82,7 @@ contract ERC20ExtendedTests is TestUtils {
     }
 
     /* ============ burn ============ */
-    function test_burn() public {
+    function test_burn() external {
         uint256 mintAmount_ = 1e18;
         uint256 burnAmount_ = 0.9e18;
 
@@ -97,7 +97,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.balanceOf(_alice), mintAmount_ - burnAmount_);
     }
 
-    function testFuzz_burn(address from_, uint256 mintAmount_, uint256 burnAmount_) public {
+    function testFuzz_burn(address from_, uint256 mintAmount_, uint256 burnAmount_) external {
         vm.assume(from_ != address(0));
         vm.assume(mintAmount_ != 0);
 
@@ -110,7 +110,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.balanceOf(from_), mintAmount_ - burnAmount_);
     }
 
-    function testFuzz_burn_insufficientBalance(address from_, uint256 mintAmount_, uint256 burnAmount_) public {
+    function testFuzz_burn_insufficientBalance(address from_, uint256 mintAmount_, uint256 burnAmount_) external {
         vm.assume(from_ != address(0));
         vm.assume(mintAmount_ != 0);
         vm.assume(mintAmount_ != type(uint256).max);
@@ -124,7 +124,7 @@ contract ERC20ExtendedTests is TestUtils {
     }
 
     /* ============ approve ============ */
-    function test_approve() public {
+    function test_approve() external {
         uint256 amount_ = 1e18;
 
         vm.expectEmit();
@@ -135,14 +135,14 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.allowance(address(this), _alice), amount_);
     }
 
-    function testFuzz_approve(address to_, uint256 amount_) public {
+    function testFuzz_approve(address to_, uint256 amount_) external {
         assertTrue(_token.approve(to_, amount_));
 
         assertEq(_token.allowance(address(this), to_), amount_);
     }
 
     /* ============ transfer ============ */
-    function test_transfer() public {
+    function test_transfer() external {
         uint256 amount_ = 1e18;
 
         _token.mint(address(this), amount_);
@@ -157,7 +157,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.balanceOf(_alice), amount_);
     }
 
-    function testFuzz_transfer(address from_, uint256 amount_) public {
+    function testFuzz_transfer(address from_, uint256 amount_) external {
         vm.assume(from_ != address(0));
         vm.assume(amount_ != 0);
 
@@ -174,14 +174,14 @@ contract ERC20ExtendedTests is TestUtils {
         }
     }
 
-    function test_transfer_insufficientBalance() public {
+    function test_transfer_insufficientBalance() external {
         _token.mint(address(this), 0.9e18);
 
         vm.expectRevert();
         _token.transfer(_alice, 1e18);
     }
 
-    function testFuzz_transfer_insufficientBalance(address to_, uint256 mintAmount_, uint256 sendAmount_) public {
+    function testFuzz_transfer_insufficientBalance(address to_, uint256 mintAmount_, uint256 sendAmount_) external {
         vm.assume(mintAmount_ != type(uint256).max);
 
         sendAmount_ = bound(sendAmount_, mintAmount_ + 1, type(uint256).max);
@@ -193,7 +193,7 @@ contract ERC20ExtendedTests is TestUtils {
     }
 
     /* ============ transferFrom ============ */
-    function test_transferFrom() public {
+    function test_transferFrom() external {
         uint256 amount_ = 1e18;
 
         _token.mint(_alice, amount_);
@@ -210,7 +210,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.balanceOf(_bob), amount_);
     }
 
-    function testFuzz_transferFrom(address to_, uint256 approval_, uint256 amount_) public {
+    function testFuzz_transferFrom(address to_, uint256 approval_, uint256 amount_) external {
         vm.assume(to_ != address(0));
 
         amount_ = bound(amount_, 0, approval_);
@@ -236,7 +236,7 @@ contract ERC20ExtendedTests is TestUtils {
         }
     }
 
-    function test_transferFrom_infiniteApprove() public {
+    function test_transferFrom_infiniteApprove() external {
         uint256 amount_ = 1e18;
 
         _token.mint(_alice, amount_);
@@ -253,7 +253,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.balanceOf(_bob), amount_);
     }
 
-    function test_transferFrom_insufficientAllowance() public {
+    function test_transferFrom_insufficientAllowance() external {
         uint256 amount_ = 1e18;
 
         _token.mint(_alice, amount_);
@@ -267,7 +267,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.transferFrom(_alice, _bob, amount_);
     }
 
-    function testFuzz_transferFrom_insufficientAllowance(address to_, uint256 approval_, uint256 amount_) public {
+    function testFuzz_transferFrom_insufficientAllowance(address to_, uint256 approval_, uint256 amount_) external {
         vm.assume(approval_ != type(uint256).max);
 
         amount_ = bound(amount_, approval_ + 1, type(uint256).max);
@@ -283,7 +283,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.transferFrom(_alice, to_, amount_);
     }
 
-    function test_transferFrom_insufficientBalance() public {
+    function test_transferFrom_insufficientBalance() external {
         uint256 amount_ = 1e18;
 
         _token.mint(_alice, 0.9e18);
@@ -295,7 +295,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.transferFrom(_alice, _bob, amount_);
     }
 
-    function testFuzz_transferFrom_insufficientBalance(address to_, uint256 mintAmount_, uint256 sendAmount_) public {
+    function testFuzz_transferFrom_insufficientBalance(address to_, uint256 mintAmount_, uint256 sendAmount_) external {
         vm.assume(mintAmount_ != type(uint256).max);
 
         sendAmount_ = bound(sendAmount_, mintAmount_ + 1, type(uint256).max);
@@ -310,7 +310,7 @@ contract ERC20ExtendedTests is TestUtils {
     }
 
     /* ============ permit ============ */
-    function test_permit() public {
+    function test_permit() external {
         uint256 amount_ = 1e18;
 
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(
@@ -327,7 +327,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.nonces(_alice), 1);
     }
 
-    function testFuzz_permit(uint248 key_, address to_, uint256 amount_, uint256 deadline_) public {
+    function testFuzz_permit(uint248 key_, address to_, uint256 amount_, uint256 deadline_) external {
         uint256 privateKey_ = key_;
 
         if (deadline_ < block.timestamp) deadline_ = block.timestamp;
@@ -349,7 +349,7 @@ contract ERC20ExtendedTests is TestUtils {
         assertEq(_token.nonces(owner_), 1);
     }
 
-    function test_permit_badNonce() public {
+    function test_permit_badNonce() external {
         uint256 amount_ = 1e18;
 
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(
@@ -367,7 +367,7 @@ contract ERC20ExtendedTests is TestUtils {
         uint256 amount_,
         uint256 deadline_,
         uint256 nonce_
-    ) public {
+    ) external {
         if (deadline_ < block.timestamp) deadline_ = block.timestamp;
         if (privateKey_ == 0) privateKey_ = 1;
         if (nonce_ == 0) nonce_ = 1;
@@ -386,7 +386,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.permit(owner_, to_, amount_, deadline_, v_, r_, s_);
     }
 
-    function test_permit_badDeadline() public {
+    function test_permit_badDeadline() external {
         uint256 amount_ = 1e18;
 
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(
@@ -398,7 +398,12 @@ contract ERC20ExtendedTests is TestUtils {
         _token.permit(_alice, _bob, amount_, block.timestamp + 1, v_, r_, s_);
     }
 
-    function testFuzz_permit_badDeadline(uint256 privateKey_, address to_, uint256 amount_, uint256 deadline_) public {
+    function testFuzz_permit_badDeadline(
+        uint256 privateKey_,
+        address to_,
+        uint256 amount_,
+        uint256 deadline_
+    ) external {
         if (deadline_ < block.timestamp) deadline_ = block.timestamp;
         if (privateKey_ == 0) privateKey_ = 1;
 
@@ -418,7 +423,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.permit(owner_, to_, amount_, deadline_ + 1, v_, r_, s_);
     }
 
-    function test_permit_pastDeadline() public {
+    function test_permit_pastDeadline() external {
         uint256 amount_ = 1e18;
         uint256 oldTimestamp_ = block.timestamp;
         uint256 newTimestamp_ = oldTimestamp_ + 1;
@@ -434,7 +439,12 @@ contract ERC20ExtendedTests is TestUtils {
         _token.permit(_alice, _bob, amount_, oldTimestamp_, v_, r_, s_);
     }
 
-    function testFuzz_permit_pastDeadline(uint256 privateKey_, address to_, uint256 amount_, uint256 deadline_) public {
+    function testFuzz_permit_pastDeadline(
+        uint256 privateKey_,
+        address to_,
+        uint256 amount_,
+        uint256 deadline_
+    ) external {
         deadline_ = bound(deadline_, 0, block.timestamp - 1);
         if (privateKey_ == 0) privateKey_ = 1;
 
@@ -452,7 +462,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.permit(owner_, to_, amount_, deadline_, v_, r_, s_);
     }
 
-    function test_permit_replay() public {
+    function test_permit_replay() external {
         uint256 amount_ = 1e18;
 
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(
@@ -466,7 +476,7 @@ contract ERC20ExtendedTests is TestUtils {
         _token.permit(_alice, _bob, amount_, block.timestamp, v_, r_, s_);
     }
 
-    function testFuzz_permit_replay(uint256 privateKey_, address to_, uint256 amount_, uint256 deadline_) public {
+    function testFuzz_permit_replay(uint256 privateKey_, address to_, uint256 amount_, uint256 deadline_) external {
         if (deadline_ < block.timestamp) deadline_ = block.timestamp;
         if (privateKey_ == 0) privateKey_ = 1;
 

--- a/test/ERC3009.t.sol
+++ b/test/ERC3009.t.sol
@@ -31,7 +31,7 @@ contract ERC3009Tests is TestUtils {
     }
 
     /* ============ TypeHashes ============ */
-    function test_transferWithAuthorizationTypehash() external {
+    function test_transferWithAuthorizationTypehash() external view {
         assertEq(
             _token.TRANSFER_WITH_AUTHORIZATION_TYPEHASH(),
             keccak256(
@@ -40,7 +40,7 @@ contract ERC3009Tests is TestUtils {
         );
     }
 
-    function test_receiveWithAuthorizationTypehash() external {
+    function test_receiveWithAuthorizationTypehash() external view {
         assertEq(
             _token.RECEIVE_WITH_AUTHORIZATION_TYPEHASH(),
             keccak256(
@@ -49,7 +49,7 @@ contract ERC3009Tests is TestUtils {
         );
     }
 
-    function test_cancelAuthorizationTypehash() external {
+    function test_cancelAuthorizationTypehash() external view {
         assertEq(
             _token.CANCEL_AUTHORIZATION_TYPEHASH(),
             keccak256("CancelAuthorization(address authorizer,bytes32 nonce)")

--- a/test/ERC712Extended.t.sol
+++ b/test/ERC712Extended.t.sol
@@ -39,7 +39,7 @@ contract ERC712ExtendedTests is TestUtils {
     }
 
     /* ============ constructor ============ */
-    function test_constructor() external {
+    function test_constructor() external view {
         assertEq(_erc712.DOMAIN_SEPARATOR(), _computeDomainSeparator(_name, block.chainid, address(_erc712)));
     }
 
@@ -65,7 +65,7 @@ contract ERC712ExtendedTests is TestUtils {
     }
 
     /* ============ digest ============ */
-    function test_digest() external {
+    function test_digest() external view {
         assertEq(
             _erc712.getDigest(_permitDigest),
             keccak256(abi.encodePacked("\x19\x01", _erc712.DOMAIN_SEPARATOR(), _permitDigest))
@@ -73,7 +73,7 @@ contract ERC712ExtendedTests is TestUtils {
     }
 
     /* ============ getSignerAndRevertIfInvalidSignature ============ */
-    function test_getSigner() external {
+    function test_getSigner() external view {
         (uint8 v_, bytes32 r_, bytes32 s_) = vm.sign(_ownerKey, _permitDigest);
 
         assertEq(_erc712.getSignerAndRevertIfInvalidSignature(_permitDigest, v_, r_, s_), address(_owner));
@@ -198,7 +198,7 @@ contract ERC712ExtendedTests is TestUtils {
     }
 
     /* ============ eip712Domain ============ */
-    function test_eip712Domain() external {
+    function test_eip712Domain() external view {
         (
             bytes1 fields_,
             string memory name_,

--- a/test/IndexingMath.t.sol
+++ b/test/IndexingMath.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.20 <0.9.0;
+
+import { Test } from "../lib/forge-std/src/Test.sol";
+
+import { IndexingMath } from "../src/libs/IndexingMath.sol";
+
+import { IndexingMathHarness } from "./utils/IndexingMathHarness.sol";
+
+contract ContinuousIndexingMathTests is Test {
+    uint56 internal constant _EXP_SCALED_ONE = IndexingMath.EXP_SCALED_ONE;
+
+    IndexingMathHarness public indexingMath;
+
+    function setUp() external {
+        indexingMath = new IndexingMathHarness();
+    }
+
+    function test_divide240By128Down() external view {
+        // Set 1a
+        assertEq(indexingMath.divide240By128Down(0, 1), 0);
+        assertEq(indexingMath.divide240By128Down(1, 1), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(2, 1), 2 * _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(3, 1), 3 * _EXP_SCALED_ONE);
+
+        // Set 1b
+        assertEq(indexingMath.divide240By128Down(1, 1), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(1, 2), _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Down(1, 3), _EXP_SCALED_ONE / 3); // Different than divideUp
+
+        // Set 2a
+        assertEq(indexingMath.divide240By128Down(0, 10), 0);
+        assertEq(indexingMath.divide240By128Down(5, 10), _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Down(10, 10), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(15, 10), _EXP_SCALED_ONE + _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Down(20, 10), 2 * _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(25, 10), 2 * _EXP_SCALED_ONE + _EXP_SCALED_ONE / 2);
+
+        // Set 2b
+        assertEq(indexingMath.divide240By128Down(10, 5), 2 * _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(10, 10), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Down(10, 15), (2 * _EXP_SCALED_ONE) / 3); // Different than divideUp
+        assertEq(indexingMath.divide240By128Down(10, 20), _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Down(10, 25), (2 * _EXP_SCALED_ONE) / 5);
+
+        // Set 3
+        assertEq(indexingMath.divide240By128Down(1, _EXP_SCALED_ONE + 1), 0); // Different than divideUp
+        assertEq(indexingMath.divide240By128Down(1, _EXP_SCALED_ONE), 1);
+        assertEq(indexingMath.divide240By128Down(1, _EXP_SCALED_ONE - 1), 1); // Different than divideUp
+        assertEq(indexingMath.divide240By128Down(1, (_EXP_SCALED_ONE / 2) + 1), 1); // Different than divideUp
+        assertEq(indexingMath.divide240By128Down(1, (_EXP_SCALED_ONE / 2)), 2);
+        assertEq(indexingMath.divide240By128Down(1, (_EXP_SCALED_ONE / 2) - 1), 2); // Different than divideUp
+    }
+
+    function test_divide240By128Up() external view {
+        // Set 1a
+        assertEq(indexingMath.divide240By128Up(0, 1), 0);
+        assertEq(indexingMath.divide240By128Up(1, 1), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(2, 1), 2 * _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(3, 1), 3 * _EXP_SCALED_ONE);
+
+        // Set 1b
+        assertEq(indexingMath.divide240By128Up(1, 1), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(1, 2), _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Up(1, 3), _EXP_SCALED_ONE / 3 + 1); // Different than divideDown
+
+        // Set 2a
+        assertEq(indexingMath.divide240By128Up(0, 10), 0);
+        assertEq(indexingMath.divide240By128Up(5, 10), _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Up(10, 10), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(15, 10), _EXP_SCALED_ONE + _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Up(20, 10), 2 * _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(25, 10), 2 * _EXP_SCALED_ONE + _EXP_SCALED_ONE / 2);
+
+        // Set 2b
+        assertEq(indexingMath.divide240By128Up(10, 5), 2 * _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(10, 10), _EXP_SCALED_ONE);
+        assertEq(indexingMath.divide240By128Up(10, 15), (2 * _EXP_SCALED_ONE) / 3 + 1); // Different than divideDown
+        assertEq(indexingMath.divide240By128Up(10, 20), _EXP_SCALED_ONE / 2);
+        assertEq(indexingMath.divide240By128Up(10, 25), (2 * _EXP_SCALED_ONE) / 5);
+
+        // Set 3
+        assertEq(indexingMath.divide240By128Up(1, _EXP_SCALED_ONE + 1), 1); // Different than divideDown
+        assertEq(indexingMath.divide240By128Up(1, _EXP_SCALED_ONE), 1);
+        assertEq(indexingMath.divide240By128Up(1, _EXP_SCALED_ONE - 1), 2); // Different than divideDown
+        assertEq(indexingMath.divide240By128Up(1, (_EXP_SCALED_ONE / 2) + 1), 2); // Different than divideDown
+        assertEq(indexingMath.divide240By128Up(1, (_EXP_SCALED_ONE / 2)), 2);
+        assertEq(indexingMath.divide240By128Up(1, (_EXP_SCALED_ONE / 2) - 1), 3); // Different than divideDown
+    }
+
+    function test_multiply112By128Down() external view {
+        // Set 1a
+        assertEq(indexingMath.multiply112By128Down(0, 1), 0);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE, 1), 1);
+        assertEq(indexingMath.multiply112By128Down(2 * _EXP_SCALED_ONE, 1), 2);
+        assertEq(indexingMath.multiply112By128Down(3 * _EXP_SCALED_ONE, 1), 3);
+
+        // Set 1b
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE, 1), 1);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE / 2, 2), 1);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE / 3, 3), 0);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE / 3 + 1, 3), 1);
+
+        // Set 2a
+        assertEq(indexingMath.multiply112By128Down(0, 10), 0);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE / 2, 10), 5);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE, 10), 10);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE + _EXP_SCALED_ONE / 2, 10), 15);
+        assertEq(indexingMath.multiply112By128Down(2 * _EXP_SCALED_ONE, 10), 20);
+        assertEq(indexingMath.multiply112By128Down(2 * _EXP_SCALED_ONE + _EXP_SCALED_ONE / 2, 10), 25);
+
+        // Set 2b
+        assertEq(indexingMath.multiply112By128Down(2 * _EXP_SCALED_ONE, 5), 10);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE, 10), 10);
+        assertEq(indexingMath.multiply112By128Down((2 * _EXP_SCALED_ONE) / 3, 15), 9);
+        assertEq(indexingMath.multiply112By128Down((2 * _EXP_SCALED_ONE) / 3 + 1, 15), 10);
+        assertEq(indexingMath.multiply112By128Down(_EXP_SCALED_ONE / 2, 20), 10);
+        assertEq(indexingMath.multiply112By128Down((2 * _EXP_SCALED_ONE) / 5, 25), 10);
+
+        // Set 3
+        assertEq(indexingMath.multiply112By128Down(1, _EXP_SCALED_ONE + 1), 1);
+        assertEq(indexingMath.multiply112By128Down(1, _EXP_SCALED_ONE), 1);
+        assertEq(indexingMath.multiply112By128Down(1, _EXP_SCALED_ONE - 1), 0);
+        assertEq(indexingMath.multiply112By128Down(1, (_EXP_SCALED_ONE / 2) + 1), 0);
+        assertEq(indexingMath.multiply112By128Down(2, (_EXP_SCALED_ONE / 2)), 1);
+        assertEq(indexingMath.multiply112By128Down(2, (_EXP_SCALED_ONE / 2) - 1), 0);
+    }
+
+    function test_multiply112By128Up() external view {
+        // Set 1a
+        assertEq(indexingMath.multiply112By128Up(0, 1), 0);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE, 1), 1);
+        assertEq(indexingMath.multiply112By128Up(2 * _EXP_SCALED_ONE, 1), 2);
+        assertEq(indexingMath.multiply112By128Up(3 * _EXP_SCALED_ONE, 1), 3);
+
+        // Set 1b
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE, 1), 1);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE / 2, 2), 1);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE / 3, 3), 1); // Different than multiplyDown
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE / 3 + 1, 3), 2); // Different than multiplyDown
+
+        // Set 2a
+        assertEq(indexingMath.multiply112By128Up(0, 10), 0);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE / 2, 10), 5);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE, 10), 10);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE + _EXP_SCALED_ONE / 2, 10), 15);
+        assertEq(indexingMath.multiply112By128Up(2 * _EXP_SCALED_ONE, 10), 20);
+        assertEq(indexingMath.multiply112By128Up(2 * _EXP_SCALED_ONE + _EXP_SCALED_ONE / 2, 10), 25);
+
+        // Set 2b
+        assertEq(indexingMath.multiply112By128Up(2 * _EXP_SCALED_ONE, 5), 10);
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE, 10), 10);
+        assertEq(indexingMath.multiply112By128Up((2 * _EXP_SCALED_ONE) / 3, 15), 10); // Different than multiplyDown
+        assertEq(indexingMath.multiply112By128Up((2 * _EXP_SCALED_ONE) / 3 + 1, 15), 11); // Different than multiplyDown
+        assertEq(indexingMath.multiply112By128Up(_EXP_SCALED_ONE / 2, 20), 10);
+        assertEq(indexingMath.multiply112By128Up((2 * _EXP_SCALED_ONE) / 5, 25), 10);
+
+        // Set 3
+        assertEq(indexingMath.multiply112By128Up(1, _EXP_SCALED_ONE + 1), 2); // Different than multiplyDown
+        assertEq(indexingMath.multiply112By128Up(1, _EXP_SCALED_ONE), 1);
+        assertEq(indexingMath.multiply112By128Up(1, _EXP_SCALED_ONE - 1), 1); // Different than multiplyDown
+        assertEq(indexingMath.multiply112By128Up(1, (_EXP_SCALED_ONE / 2) + 1), 1); // Different than multiplyDown
+        assertEq(indexingMath.multiply112By128Up(2, (_EXP_SCALED_ONE / 2)), 1);
+        assertEq(indexingMath.multiply112By128Up(2, (_EXP_SCALED_ONE / 2) - 1), 1); // Different than multiplyDown
+    }
+}

--- a/test/SignatureChecker.t.sol
+++ b/test/SignatureChecker.t.sol
@@ -52,7 +52,7 @@ contract SignatureCheckerTests is TestUtils {
         _signatureChecker = new SignatureCheckerHarness();
     }
 
-    function test_decodeECDSASignature() external {
+    function test_decodeECDSASignature() external view {
         (uint8 v_, bytes32 r_, bytes32 s_) = _signatureChecker.decodeECDSASignature(
             _encodeSignature(18, "TEST_R", "TEST_S")
         );
@@ -62,7 +62,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(s_, bytes32("TEST_S"));
     }
 
-    function testFuzz_decodeECDSASignature(uint256 v, uint256 r, uint256 s) external {
+    function testFuzz_decodeECDSASignature(uint256 v, uint256 r, uint256 s) external view {
         (uint8 v_, bytes32 r_, bytes32 s_) = _signatureChecker.decodeECDSASignature(
             _encodeSignature(uint8(v), bytes32(r), bytes32(s))
         );
@@ -72,7 +72,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(s_, bytes32(s));
     }
 
-    function test_recoverECDSASigner_vrs_invalidSignatureS() external {
+    function test_recoverECDSASigner_vrs_invalidSignatureS() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(
             0x00,
             0x00,
@@ -84,14 +84,14 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer, address(0));
     }
 
-    function test_recoverECDSASigner_vrs_invalidSignatureV() external {
+    function test_recoverECDSASigner_vrs_invalidSignatureV() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(0x00, 26, 0x00, 0x00);
 
         assertEq(uint8(error_), uint8(SignatureChecker.Error.InvalidSignatureV));
         assertEq(signer, address(0));
     }
 
-    function test_recoverECDSASigner_vrs_invalidSignature() external {
+    function test_recoverECDSASigner_vrs_invalidSignature() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(0x00, 27, 0x00, 0x00);
 
         assertEq(uint8(error_), uint8(SignatureChecker.Error.InvalidSignature));
@@ -120,7 +120,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer_, account_);
     }
 
-    function test_recoverECDSASigner_rvs_invalidSignatureS() external {
+    function test_recoverECDSASigner_rvs_invalidSignatureS() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(
             0x00,
             0x00,
@@ -131,7 +131,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer, address(0));
     }
 
-    function test_recoverECDSASigner_rvs_invalidSignature() external {
+    function test_recoverECDSASigner_rvs_invalidSignature() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(0x00, 0x00, 0x00);
 
         assertEq(uint8(error_), uint8(SignatureChecker.Error.InvalidSignature));
@@ -168,7 +168,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer_, account_);
     }
 
-    function test_recoverECDSASigner_bytes_invalidSignatureS() external {
+    function test_recoverECDSASigner_bytes_invalidSignatureS() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(
             0x00,
             _encodeSignature(0x00, 0x00, bytes32(_MAX_S + 1))
@@ -178,7 +178,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer, address(0));
     }
 
-    function test_recoverECDSASigner_bytes_invalidSignatureV() external {
+    function test_recoverECDSASigner_bytes_invalidSignatureV() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(
             0x00,
             _encodeSignature(26, 0x00, 0x00)
@@ -188,7 +188,7 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer, address(0));
     }
 
-    function test_recoverECDSASigner_bytes_invalidSignature() external {
+    function test_recoverECDSASigner_bytes_invalidSignature() external view {
         (SignatureChecker.Error error_, address signer) = _signatureChecker.recoverECDSASigner(
             0x00,
             _encodeSignature(27, 0x00, 0x00)
@@ -226,14 +226,14 @@ contract SignatureCheckerTests is TestUtils {
         assertEq(signer_, account_);
     }
 
-    function test_validateRecoveredSigner_mismatch() external {
+    function test_validateRecoveredSigner_mismatch() external view {
         assertEq(
             uint8(_signatureChecker.validateRecoveredSigner(address(0), address(1))),
             uint8(SignatureChecker.Error.SignerMismatch)
         );
     }
 
-    function test_validateRecoveredSigner() external {
+    function test_validateRecoveredSigner() external view {
         assertEq(
             uint8(_signatureChecker.validateRecoveredSigner(address(1), address(1))),
             uint8(SignatureChecker.Error.NoError)

--- a/test/UIntMath.t.sol
+++ b/test/UIntMath.t.sol
@@ -53,53 +53,53 @@ contract UIntMathTests is Test {
         _uintMath.safe240(uint256(type(uint240).max) + 1);
     }
 
-    function test_bound32() external {
+    function test_bound32() external view {
         assertEq(_uintMath.bound32(uint256(type(uint32).max) + 1), type(uint32).max);
     }
 
-    function test_bound112() external {
+    function test_bound112() external view {
         assertEq(_uintMath.bound112(uint256(type(uint112).max) + 1), type(uint112).max);
     }
 
-    function test_bound128() external {
+    function test_bound128() external view {
         assertEq(_uintMath.bound128(uint256(type(uint128).max) + 1), type(uint128).max);
     }
 
-    function test_bound240() external {
+    function test_bound240() external view {
         assertEq(_uintMath.bound240(uint256(type(uint240).max) + 1), type(uint240).max);
     }
 
-    function test_max32() external {
+    function test_max32() external view {
         assertEq(_uintMath.max32(1, 2), 2);
         assertEq(_uintMath.max32(2, 1), 2);
     }
 
-    function test_max40() external {
+    function test_max40() external view {
         assertEq(_uintMath.max40(1, 2), 2);
         assertEq(_uintMath.max40(2, 1), 2);
     }
 
-    function test_min32() external {
+    function test_min32() external view {
         assertEq(_uintMath.min32(1, 2), 1);
         assertEq(_uintMath.min32(2, 1), 1);
     }
 
-    function test_min40() external {
+    function test_min40() external view {
         assertEq(_uintMath.min40(1, 2), 1);
         assertEq(_uintMath.min40(2, 1), 1);
     }
 
-    function test_min112() external {
+    function test_min112() external view {
         assertEq(_uintMath.min112(1, 2), 1);
         assertEq(_uintMath.min112(2, 1), 1);
     }
 
-    function test_min240() external {
+    function test_min240() external view {
         assertEq(_uintMath.min240(1, 2), 1);
         assertEq(_uintMath.min240(2, 1), 1);
     }
 
-    function test_min256() external {
+    function test_min256() external view {
         assertEq(_uintMath.min256(1, 2), 1);
         assertEq(_uintMath.min256(2, 1), 1);
     }

--- a/test/invariant/ERC20ExtendedInvariant.t.sol
+++ b/test/invariant/ERC20ExtendedInvariant.t.sol
@@ -17,7 +17,7 @@ contract ERC20ExtendedHandler is CommonBase, StdCheats, StdUtils {
         _token = token_;
     }
 
-    function mint(address to_, uint256 amount_) public {
+    function mint(address to_, uint256 amount_) external {
         if (to_ == address(0)) return;
 
         amount_ = bound(amount_, 0, type(uint256).max - sum);
@@ -26,18 +26,18 @@ contract ERC20ExtendedHandler is CommonBase, StdCheats, StdUtils {
         sum += amount_;
     }
 
-    function burn(address from_, uint256 amount_) public {
+    function burn(address from_, uint256 amount_) external {
         amount_ = bound(amount_, 0, _token.balanceOf(from_));
 
         _token.burn(from_, amount_);
         sum -= amount_;
     }
 
-    function approve(address to_, uint256 amount_) public {
+    function approve(address to_, uint256 amount_) external {
         _token.approve(to_, amount_);
     }
 
-    function transferFrom(address from_, address to_, uint256 amount_) public {
+    function transferFrom(address from_, address to_, uint256 amount_) external {
         if (from_ == address(0) || to_ == address(0)) return;
 
         amount_ = bound(amount_, 0, _token.balanceOf(from_));
@@ -54,7 +54,7 @@ contract ERC20ExtendedHandler is CommonBase, StdCheats, StdUtils {
         _token.transferFrom(from_, to_, amount_);
     }
 
-    function transfer(address to_, uint256 amount_) public {
+    function transfer(address to_, uint256 amount_) external {
         if (msg.sender == address(0) || to_ == address(0)) return;
 
         amount_ = bound(amount_, 0, _token.balanceOf(msg.sender));
@@ -77,7 +77,7 @@ contract ERC20ExtendedInvariantTests is TestUtils {
     ERC20ExtendedHarness internal _token;
     ERC20ExtendedHandler internal _handler;
 
-    function setUp() public {
+    function setUp() external {
         _token = new ERC20ExtendedHarness("ERC20Extended Token", "ERC20E_TKN", 18);
         _handler = new ERC20ExtendedHandler(_token);
 
@@ -93,7 +93,7 @@ contract ERC20ExtendedInvariantTests is TestUtils {
         targetSelector(FuzzSelector({ addr: address(_handler), selectors: selectors }));
     }
 
-    function invariant_main() public {
+    function invariant_main() external view {
         assertEq(_token.totalSupply(), _handler.sum());
     }
 }

--- a/test/utils/ContinuousIndexingMathHarness.sol
+++ b/test/utils/ContinuousIndexingMathHarness.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.20 <0.9.0;
+
+import { ContinuousIndexingMath } from "../../src/libs/ContinuousIndexingMath.sol";
+
+// Note: This harness contract is needed cause internal library functions can be inlined by the compiler
+//       and won't be picked up by forge coverage
+// See: https://github.com/foundry-rs/foundry/issues/6308#issuecomment-1866878768
+contract ContinuousIndexingMathHarness {
+    function multiplyIndicesDown(uint128 index, uint48 deltaIndex) external pure returns (uint144) {
+        return ContinuousIndexingMath.multiplyIndicesDown(index, deltaIndex);
+    }
+
+    function multiplyIndicesUp(uint128 index, uint48 deltaIndex) external pure returns (uint144) {
+        return ContinuousIndexingMath.multiplyIndicesUp(index, deltaIndex);
+    }
+
+    function getContinuousIndex(uint64 yearlyRate, uint32 time) external pure returns (uint48) {
+        return ContinuousIndexingMath.getContinuousIndex(yearlyRate, time);
+    }
+
+    function exponent(uint72 x) external pure returns (uint48 y) {
+        return ContinuousIndexingMath.exponent(x);
+    }
+
+    function convertToBasisPoints(uint64 input) external pure returns (uint40) {
+        return ContinuousIndexingMath.convertToBasisPoints(input);
+    }
+
+    function convertFromBasisPoints(uint32 input) external pure returns (uint64) {
+        return ContinuousIndexingMath.convertFromBasisPoints(input);
+    }
+}

--- a/test/utils/IndexingMathHarness.sol
+++ b/test/utils/IndexingMathHarness.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.20 <0.9.0;
+
+import { IndexingMath } from "../../src/libs/IndexingMath.sol";
+
+// Note: This harness contract is needed cause internal library functions can be inlined by the compiler
+//       and won't be picked up by forge coverage
+// See: https://github.com/foundry-rs/foundry/issues/6308#issuecomment-1866878768
+contract IndexingMathHarness {
+    function divide240By128Down(uint240 x, uint128 index) external pure returns (uint112 z) {
+        return IndexingMath.divide240By128Down(x, index);
+    }
+
+    function divide240By128Up(uint240 x, uint128 index) external pure returns (uint112 z) {
+        return IndexingMath.divide240By128Up(x, index);
+    }
+
+    function multiply112By128Down(uint112 x, uint128 index) external pure returns (uint240 z) {
+        return IndexingMath.multiply112By128Down(x, index);
+    }
+
+    function multiply112By128Up(uint112 x, uint128 index) external pure returns (uint240 z) {
+        return IndexingMath.multiply112By128Up(x, index);
+    }
+}


### PR DESCRIPTION
- remove compile/test warnings
- since libraries do not have public variables, there is no possibility for shadow variables, so no need for underscore suffixes