### PR TITLE
Add Multisig Batch utility for forge scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
 	branch = release-v5.3
+[submodule "lib/safe-utils"]
+	path = lib/safe-utils
+	url = https://github.com/Recon-Fuzz/safe-utils

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,7 +17,6 @@ block_number = 17_740_856
 block_timestamp = 1_689_934_508
 # Ignore base test files to avoid running tests twice
 no_match_path = "./test/base/*.t.sol"
-ignored_warnings_from = ["lib", "test", "script"]
 
 [lint]
 lint_on_build = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,10 @@ block_number = 17_740_856
 block_timestamp = 1_689_934_508
 # Ignore base test files to avoid running tests twice
 no_match_path = "./test/base/*.t.sol"
+ignored_warnings_from = ["lib", "test", "script"]
+
+[lint]
+lint_on_build = false
 
 [profile.default.fuzz]
 runs = 256

--- a/script/MultiSigBatchBase.sol
+++ b/script/MultiSigBatchBase.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.20 <0.9.0;
+
+import { Safe } from "../lib/safe-utils/src/Safe.sol";
+import { Script } from "../lib/forge-std/src/Script.sol";
+
+abstract contract MultiSigBatchBase is Script {
+    using Safe for *;
+
+    Safe.Client internal _safeMultiSig;
+    address[] internal _targets;
+    bytes[] internal _data;
+
+    function _addToBatch(address target_, bytes memory data_) internal {
+        _targets.push(target_);
+        _data.push(data_);
+    }
+
+    function _proposeBatch(address safe_, address sender) internal {
+        _safeMultiSig.initialize(safe_);
+        _safeMultiSig.proposeTransactions(_targets, _data, sender, "");
+    }
+
+    function _simulateBatch(address safe_) internal {
+        vm.startPrank(safe_);
+
+        for (uint256 i = 0; i < _targets.length; i++) {
+            (bool success, ) = _targets[i].call(_data[i]);
+            require(success, "Simulation failed");
+        }
+
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
Summary
This PR relocates MultiSigBatchBase.sol from m-portal-lite into the common package so it can be shared across repositories. Since multisig batch operations will be used across multiple projects for upgrades and related scripting tasks, centralizing this contract in common avoids duplication and ensures consistent behavior.

Motivation
MultiSigBatchBase.sol exists only in [m-portal-lite](https://github.com/m0-foundation/m-portal-lite/blob/main/script/MultiSigBatchBase.sol), but upcoming workflows require multisig batch operations in several repos. Moving this contract into common allows all repositories to import the same implementation directly, rather than maintaining multiple copies.

Changes
	•	Added MultiSigBatchBase.sol to the common package
	•	Updated foundry.toml to ignore safe-utils lint warnings
	•	Imported the same version of safe-utils used in m-portal-lite (latest version introduced breaking import errors, so this PR uses the compatible release)
	
Next steps
remove `MultisigBatchBase.sol` [m-portal-lite](https://github.com/m0-foundation/m-portal-lite/blob/main) to reference the one now in `common`
